### PR TITLE
Added Jamalpur Science & Technology University

### DIFF
--- a/lib/domains/bd/ac/jstu.txt
+++ b/lib/domains/bd/ac/jstu.txt
@@ -1,0 +1,1 @@
+Jamalpur Science & Technology University


### PR DESCRIPTION
Jamalpur Science and Technology University (Bengali: জামালপুর বিজ্ঞান ও প্রযুক্তি বিশ্ববিদ্যালয়) is a government financed public university of Bangladesh. It was established on 28 November 2017 by the Act No. 24 of 2017 as the 44th public university of Bangladesh. Later it was renamed in 2024 as Jamalpur Science and Technology University. 
Website: https://jstu.ac.bd/
Wikipedia: https://en.wikipedia.org/wiki/Jamalpur_Science_and_Technology_University